### PR TITLE
Externalize feed config

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,23 @@ conda activate ai-news-agent
 export PYTHONPATH=src
 python src/main.py
 ```
+
+## Feed configuration
+
+The collector reads RSS feed URLs from `feeds.json` in the project root. The
+file should contain a JSON object where each key is a feed URL and each value
+specifies the `category` and human‑readable `source` name.
+
+Example:
+
+```json
+{
+  "https://openai.com/news/rss.xml": {
+    "category": "Lab Blogs",
+    "source": "OpenAI"
+  }
+}
+```
+
+Feeds defined in this file are used by the collector. If the file is missing or
+invalid, no feeds will be loaded.

--- a/feeds.json
+++ b/feeds.json
@@ -1,0 +1,58 @@
+{
+  "https://openai.com/news/rss.xml": {
+    "category": "Lab Blogs",
+    "source": "OpenAI"
+  },
+  "https://blog.google/technology/ai/rss/": {
+    "category": "Lab Blogs",
+    "source": "Google"
+  },
+  "https://huggingface.co/blog/feed.xml": {
+    "category": "Lab Blogs",
+    "source": "Hugging Face"
+  },
+  "https://www.technologyreview.com/topic/artificial-intelligence/feed/": {
+    "category": "News & Mags",
+    "source": "MIT Technology Review"
+  },
+  "https://www.wired.com/feed/tag/ai/latest/rss": {
+    "category": "News & Mags",
+    "source": "Wired"
+  },
+  "https://feeds.arstechnica.com/arstechnica/technology-lab": {
+    "category": "News & Mags",
+    "source": "Ars Technica"
+  },
+  "https://techcrunch.com/tag/artificial-intelligence/feed/": {
+    "category": "News & Mags",
+    "source": "TechCrunch"
+  },
+  "https://venturebeat.com/category/ai/feed/": {
+    "category": "News & Mags",
+    "source": "VentureBeat"
+  },
+  "https://thesequence.substack.com/feed": {
+    "category": "Newsletters",
+    "source": "The Sequence"
+  },
+  "https://importai.substack.com/feed": {
+    "category": "Newsletters",
+    "source": "Import AI"
+  },
+  "https://www.latent.space/feed.xml": {
+    "category": "Newsletters",
+    "source": "Latent Space"
+  },
+  "https://aibreakfast.substack.com/feed": {
+    "category": "Newsletters",
+    "source": "AI Breakfast"
+  },
+  "https://arxiv.org/rss/cs.CL": {
+    "category": "Research",
+    "source": "arXiv"
+  },
+  "https://jamesg.blog/hf-papers.xml": {
+    "category": "Research",
+    "source": "Hugging Face Papers"
+  }
+}

--- a/src/collector.py
+++ b/src/collector.py
@@ -1,73 +1,16 @@
-import feedparser, hashlib, time
+import feedparser, hashlib, json, time
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 
 _DAY = timedelta(days=1)
 
-FEEDS = {
-    # Lab & Research blogs
-    "https://openai.com/news/rss.xml": {
-        "category": "Lab Blogs",
-        "source": "OpenAI"
-    },
-    "https://blog.google/technology/ai/rss/": {
-        "category": "Lab Blogs",
-        "source": "Google"
-    },
-    "https://huggingface.co/blog/feed.xml": {
-        "category": "Lab Blogs",
-        "source": "Hugging Face"
-    },
+# Location of feeds configuration file (project root)
+_FEEDS_FILE = Path(__file__).resolve().parent.parent / "feeds.json"
 
-    # News & Magazines
-    "https://www.technologyreview.com/topic/artificial-intelligence/feed/": {
-        "category": "News & Mags",
-        "source": "MIT Technology Review"
-    },
-    "https://www.wired.com/feed/tag/ai/latest/rss": {
-        "category": "News & Mags",
-        "source": "Wired"
-    },
-    "https://feeds.arstechnica.com/arstechnica/technology-lab": {
-        "category": "News & Mags",
-        "source": "Ars Technica"
-    },
-    "https://techcrunch.com/tag/artificial-intelligence/feed/": {
-        "category": "News & Mags",
-        "source": "TechCrunch"
-    },
-    "https://venturebeat.com/category/ai/feed/": {
-        "category": "News & Mags",
-        "source": "VentureBeat"
-    },
-
-    # Newsletters / Aggregators
-    "https://thesequence.substack.com/feed": {
-        "category": "Newsletters",
-        "source": "The Sequence"
-    },
-    "https://importai.substack.com/feed": {
-        "category": "Newsletters",
-        "source": "Import AI"
-    },
-    "https://www.latent.space/feed.xml": {
-        "category": "Newsletters",
-        "source": "Latent Space"
-    },
-    "https://aibreakfast.substack.com/feed": {
-        "category": "Newsletters",
-        "source": "AI Breakfast"
-    },
-
-    # Research
-    "https://arxiv.org/rss/cs.CL": {
-        "category": "Research",
-        "source": "arXiv"
-    },
-    "https://jamesg.blog/hf-papers.xml": {
-        "category": "Research",
-        "source": "Hugging Face Papers"
-    },
-}
+try:
+    FEEDS = json.loads(_FEEDS_FILE.read_text())
+except (FileNotFoundError, json.JSONDecodeError):
+    FEEDS = {}
 
 def _now():
     return datetime.now(timezone.utc)


### PR DESCRIPTION
## Summary
- move built-in FEEDS dictionary to `feeds.json`
- load `feeds.json` if present, otherwise use defaults
- document config format in README

## Testing
- `python -m py_compile src/*.py`
