### PR TITLE
chore(deps): finish root security remediation

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -370,7 +370,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.2.22"
+version = "1.2.28"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonpatch" },
@@ -382,9 +382,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "uuid-utils" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b1/a3/c4cd6827a1df46c821e7214b7f7b7a28b189e6c9b84ef15c6d629c5e3179/langchain_core-1.2.22.tar.gz", hash = "sha256:8d8f726d03d3652d403da915126626bb6250747e8ba406537d849e68b9f5d058", size = 842487, upload-time = "2026-03-24T18:48:44.9Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/a4/317a1a3ac1df33a64adb3670bf88bbe3b3d5baa274db6863a979db472897/langchain_core-1.2.28.tar.gz", hash = "sha256:271a3d8bd618f795fdeba112b0753980457fc90537c46a0c11998516a74dc2cb", size = 846119, upload-time = "2026-04-08T18:19:34.867Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/a6/2ffacf0f1a3788f250e75d0b52a24896c413be11be3a6d42bcdf46fbea48/langchain_core-1.2.22-py3-none-any.whl", hash = "sha256:7e30d586b75918e828833b9ec1efc25465723566845dd652c277baf751e9c04b", size = 506829, upload-time = "2026-03-24T18:48:43.286Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/92/32f785f077c7e898da97064f113c73fbd9ad55d1e2169cf3a391b183dedb/langchain_core-1.2.28-py3-none-any.whl", hash = "sha256:80764232581eaf8057bcefa71dbf8adc1f6a28d257ebd8b95ba9b8b452e8c6ac", size = 508727, upload-time = "2026-04-08T18:19:32.823Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This follow-up PR completes the remaining `Dependabot` remediation for `nickzren/ai-news-agent` after the first lock-only merge moved `langchain-core` onto the `1.x` line and surfaced one additional advisory on that line.

- scope: `nickzren/ai-news-agent`
- base branch: `main`
- target: `root`
- diff shape: `uv.lock` only
- verification:
  - `uv sync --locked --extra dev`
  - `uv run pytest -q`
  - `uv run mypy src`

<!-- github-security-agent
{"schema_version":"v1","remediation_key":"nickzren/ai-news-agent+dependabot+main+root","alert_class":"dependabot","target_id":"root","base_branch":"main","advisory_ids":["GHSA-926x-3r5x-gfhw"],"agent_version":"codex-manual-run","last_pass_at":"2026-04-16T20:03:26Z"}
-->
